### PR TITLE
fix(deploy): improve logging permissions and client build order

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -12,8 +12,8 @@ RUN pnpm install --filter client...
 
 COPY apps/client ./apps/client
 
-WORKDIR /app/apps/client
-RUN pnpm run build
+RUN pnpm run build --filter client...
+
 
 FROM nginx:alpine
 

--- a/scripts/backup-postgres.sh
+++ b/scripts/backup-postgres.sh
@@ -8,12 +8,24 @@ BACKUP_FILENAME="physio-backup-${TIMESTAMP}.sql"
 ENCRYPTED_FILENAME="${BACKUP_FILENAME}.gpg"
 LOG_FILE="${LOG_FILE:-/var/log/physio-backup.log}"
 
+if [ ! -w "$(dirname "$LOG_FILE")" ] && [ "$EUID" -ne 0 ]; then
+    LOG_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/physio"
+    mkdir -p "$LOG_DIR"
+    LOG_FILE="$LOG_DIR/backup.log"
+    echo "Warning: No write permission for /var/log. Logging to $LOG_FILE"
+fi
+
+if [ ! -w "$(dirname "$BACKUP_DIR")" ] && [ "$EUID" -ne 0 ]; then
+   BACKUP_DIR="${HOME}/backups/physio"
+   echo "Warning: No write permission for /var/backups. Saving backups to $BACKUP_DIR"
+fi
+
 # Ensure backup directory exists
 mkdir -p "$BACKUP_DIR"
 chmod 700 "$BACKUP_DIR"
 
 log() {
-    echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> "$LOG_FILE"
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" | tee -a "$LOG_FILE"
 }
 
 error_exit() {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,6 +4,12 @@
 COMPOSE_FILE="docker-compose.prod.yml"
 LOG_FILE="${LOG_FILE:-/var/log/physio-deploy.log}"
 
+# Check write permissions for log file
+if [ ! -w "$(dirname "$LOG_FILE")" ] && [ "$EUID" -ne 0 ]; then
+    LOG_FILE="./physio-deploy.log"
+    echo "Warning: No write permission for /var/log. Logging to $LOG_FILE"
+fi
+
 log() {
     echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" | tee -a "$LOG_FILE"
 }


### PR DESCRIPTION
This commit addresses deployment issues on non-root environments and fixes a client build failure.

- scripts/deploy.sh: Add smart fallback for logging. If /var/log is not writable, logs are written to the local directory './physio-deploy.log'. Removed the sudo requirement.
- scripts/backup-postgres.sh: Add smart fallback for logging and backup directories. Uses XDG_STATE_HOME (~/.local/state/physio) for logs and ~/backups/physio for backups if system directories are not writable. Updated logging to output to stdout + file.
- docker/client/Dockerfile: Fix build command to 'pnpm run build --filter client...' to ensure workspace dependencies (like @mamirri/logger) are built before the client application.