### PR TITLE
fix(docker): copy turbo.json for client build

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -12,6 +12,7 @@ RUN pnpm install --filter client...
 
 COPY apps/client ./apps/client
 
+COPY turbo.json ./
 RUN pnpm run build --filter client...
 
 


### PR DESCRIPTION
This commit fixes the client Docker build failure by ensuring turbo.json is available in the container context. This is required because the build script uses Turborepo.