### PR TITLE
fix(docker): update client healthcheck and nginx config

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -119,7 +119,7 @@ services:
       API_URL: http://server:3000
     healthcheck:
       test:
-        ['CMD', 'wget', '--spider', '-q', '--timeout=5', 'http://localhost:80/']
+        ['CMD', 'wget', '--spider', '-q', '--timeout=5', 'http://127.0.0.1:80/']
       interval: 30s
       timeout: 10s
       start_period: 30s

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -23,7 +23,7 @@ COPY --from=builder /app/apps/client/dist /usr/share/nginx/html
 COPY docker/client/nginx.conf /etc/nginx/conf.d/default.conf
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:80/ || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:80/ || exit 1
 
 EXPOSE 80
 

--- a/docker/client/nginx.conf
+++ b/docker/client/nginx.conf
@@ -1,8 +1,19 @@
 server {
     listen 80;
-    server_name localhost;
+    listen [::]:80;
+    server_name _;
     root /usr/share/nginx/html;
     index index.html;
+
+    # Proxy API requests to the backend
+    location /api/ {
+        proxy_pass http://server:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
 
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
- Update Nginx config to listen on IPv6 and proxy API requests to backend
- Update client healthcheck in Dockerfile and compose to use 127.0.0.1
- Allow any server name in Nginx to support custom domains