### PR TITLE
fix(deploy): use external network and prevent full teardown

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -145,4 +145,4 @@ volumes:
 
 networks:
   homelab_net:
-    driver: bridge
+    external: true

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -270,8 +270,8 @@ deploy_services() {
     
 
     # Stop existing containers gracefully
-    log "Stopping existing containers..."
-    run_cmd docker compose -f "$COMPOSE_FILE" down --timeout 30
+    # log "Stopping existing containers..."
+    # run_cmd docker compose -f "$COMPOSE_FILE" down --timeout 30
 
     # Build or pull images
     if grep -q "build:" "$COMPOSE_FILE"; then


### PR DESCRIPTION
- Set homelab_net to external: true in docker-compose.prod.yml to use existing shared network
- Disable 'docker compose down' in deploy script to prevent stopping db/volumes and removing network
- Ensure zero-downtime updates for unchanged services