### PR TITLE
fix(storage): improve minio endpoint config and audio playback error handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,8 @@ MINIO_ROOT_PASSWORD=minioadmin_change_me
 MINIO_PORT=9000
 MINIO_CONSOLE_PORT=9001
 MINIO_BUCKET=physio-media
+MINIO_PUBLIC_ENDPOINT=http://localhost:9000
+
 
 # Server uses these
 STORAGE_TYPE=minio

--- a/apps/client/src/components/patients/VoiceNotesSection.tsx
+++ b/apps/client/src/components/patients/VoiceNotesSection.tsx
@@ -4,6 +4,7 @@ import type { VoiceNote } from '../../types/patient';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { useToast } from '../../hooks/use-toast';
 
 interface VoiceNotesSectionProps {
   voiceNotes?: VoiceNote[];
@@ -16,6 +17,7 @@ export function VoiceNotesSection({
   title = 'Notas de Voz',
   className,
 }: VoiceNotesSectionProps) {
+  const { toast } = useToast();
   const [expandedNoteId, setExpandedNoteId] = useState<string | null>(
     voiceNotes.length > 0 ? voiceNotes[0].id : null,
   );
@@ -171,14 +173,26 @@ export function VoiceNotesSection({
                       if (audio) {
                         try {
                           if (audio.paused) {
-                            audio.play().catch(() => {
-                              // Fallback: let the native controls handle playback
+                            audio.play().catch((err) => {
+                              console.error('Audio playback error:', err);
+                              toast({
+                                variant: 'destructive',
+                                title: 'Error de reproducción',
+                                description:
+                                  'No se pudo reproducir el audio. Verifica tu conexión.',
+                              });
                             });
                           } else {
                             audio.pause();
                           }
-                        } catch {
-                          // Fallback: let the native controls handle playback
+                        } catch (err) {
+                          console.error('Audio control error:', err);
+                          toast({
+                            variant: 'destructive',
+                            title: 'Error de audio',
+                            description:
+                              'Ocurrió un problema al controlar el audio.',
+                          });
                         }
                       }
                     }}
@@ -191,6 +205,15 @@ export function VoiceNotesSection({
                     controls
                     className="flex-1 h-8"
                     controlsList="nodownload"
+                    onError={(e) => {
+                      console.error('Audio loading error:', e);
+                      toast({
+                        variant: 'destructive',
+                        title: 'Error de carga',
+                        description:
+                          'No se pudo cargar el archivo de audio. Verifica que el archivo exista y sea accesible.',
+                      });
+                    }}
                   />
                 </div>
 

--- a/apps/server/src/modules/storage/storage.service.ts
+++ b/apps/server/src/modules/storage/storage.service.ts
@@ -109,6 +109,9 @@ export class StorageService implements OnModuleInit {
         forcePathStyle: true,
       });
     } else {
+      this.logger.warn(
+        'MINIO_PUBLIC_ENDPOINT is not set. URLs will be signed using the internal endpoint. This may cause issues if the client cannot reach the internal endpoint.',
+      );
       this.signingClient = this.client;
     }
   }
@@ -216,6 +219,7 @@ export class StorageService implements OnModuleInit {
       const url = await getSignedUrl(this.signingClient, command, {
         expiresIn: expiry,
       });
+      this.logger.debug(`Generated signed URL for ${path}: ${url}`);
       return url;
     } catch (error) {
       if (this.isNotFoundError(error)) {


### PR DESCRIPTION
## Summary
This PR addresses issues with audio playback in production by improving configuration visibility and error handling.

### Changes
- **Backend**: 
  - Added startup logging/warning in `StorageService` regarding `MINIO_PUBLIC_ENDPOINT`.
  - Added debug logging to `getFileUrl` to trace the actual signed URLs being generated.
- **Frontend**: 
  - Added user feedback (toast notifications) in `VoiceNotesSection` when audio playback fails, replacing silent failures.
- **Docs**: 
  - Updated `.env.example` to include the critical `MINIO_PUBLIC_ENDPOINT` variable.

## Testing
- Verified locally that missing env var triggers warning log.
- Verified that audio playback errors now show a toast message.