### PR TITLE
fix(client): prevent clipping on active treatment filters

### DIFF
--- a/apps/client/src/components/patients/PatientList.tsx
+++ b/apps/client/src/components/patients/PatientList.tsx
@@ -92,7 +92,7 @@ export function PatientList({
     const baseClasses =
       'px-4 py-2 rounded-full font-medium transition-all duration-200 whitespace-nowrap text-sm';
     const activeClasses =
-      'bg-teal-600 text-white shadow-md ring-2 ring-teal-600 ring-offset-2 dark:ring-offset-slate-900';
+      'bg-teal-600 text-white shadow-md border border-teal-600';
     const inactiveClasses =
       'bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-700 border border-slate-200 dark:border-slate-700';
 
@@ -143,7 +143,7 @@ export function PatientList({
           )}
         </div>
 
-        <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-hide">
+        <div className="flex gap-2 overflow-x-auto py-1 scrollbar-hide">
           <button
             onClick={() => handleFilterChange('all')}
             className={getFilterClasses('all', activeFilter === 'all')}

--- a/apps/client/src/components/patients/treatment-timeline/PhaseProgress.tsx
+++ b/apps/client/src/components/patients/treatment-timeline/PhaseProgress.tsx
@@ -40,7 +40,7 @@ export function PhaseProgress({
         )}
       </div>
 
-      <div className="flex items-start gap-2 overflow-x-auto pb-2">
+      <div className="flex items-start gap-2 overflow-x-auto py-1">
         {phases.map((phase, index) => {
           const sessionCount = getSessionCount(phase.number);
           const completed = isPhaseCompleted(phase.number);
@@ -52,10 +52,10 @@ export function PhaseProgress({
               <button
                 onClick={() => onPhaseClick(selected ? null : phase.number)}
                 className={cn(
-                  'flex flex-col items-center min-w-[80px] p-2 rounded-lg transition-all',
+                  'flex flex-col items-center min-w-[80px] p-2 rounded-lg border border-transparent transition-all',
                   'focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2',
                   selected
-                    ? 'bg-teal-50 dark:bg-teal-900/30 ring-2 ring-teal-500'
+                    ? 'bg-teal-50 dark:bg-teal-900/30 border-teal-500'
                     : 'hover:bg-slate-100 dark:hover:bg-slate-800',
                 )}
                 aria-pressed={selected}


### PR DESCRIPTION
## Summary
- fix active filter chip clipping on `Pacientes` by replacing offset ring highlight with border highlight and adding vertical breathing room in the chip row
- fix clipping in `Cronograma de Tratamiento` > `Fases del Tratamiento` by switching selected phase highlight from outer ring to border and adding vertical padding in the horizontal phase list
- keep active-state contrast and behavior intact while avoiding overflow clipping artifacts

## Validation
- pnpm --filter client check-types
- pnpm --filter client test -- src/components/patients/treatment-timeline/PhaseProgress.test.tsx
- pnpm --filter client build

Closes #39