### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-02-25
+
+### Added
+
+- **Multi-tenancy Foundation**: Implemented core logic for clinics, roles, and onboarding.
+- **Clinic Onboarding Wizard**: Multi-step flow for creating clinics, branding, and inviting teams.
+- **Medical Library (Biblioteca Médica)**: Categorized clinical protocols, hybrid search (keyword + semantic), and detail views.
+- **Clinical Cases & AI Analysis**: Enhanced case management with automated analysis and feedback loops.
+- **Patient Management**: Full CRUD for patients with timeline views and profile optimizations.
+- **Infrastructure**: Sentry integration, updated database migrations, and CI/CD enhancements.
+
+### Changed
+
+- Improved overall performance and UI/UX across the platform.
+- Refactored authentication and authorization for clinic-specific contexts.
+
+### Fixed
+
+- Resolved numerous lint errors and test failures across the monorepo.
+- Fixed UI clipping issues and navigation bugs.

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "",
   "author": "",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "mamirri-app",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "build": "turbo run build",


### PR DESCRIPTION
## Release v1.0.0
This PR bumps the version to `1.0.0` and adds the initial `CHANGELOG.md`.

### Tasks after merge:
1. Create tag `v1.0.0` on `main`.
2. Create GitHub Release using `gh release create v1.0.0 --generate-notes`.