### PR TITLE
hotfix: Fix server production entrypoint path

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -107,4 +107,4 @@ WORKDIR /app/apps/server
 EXPOSE 3000
 
 ENTRYPOINT ["entrypoint.sh"]
-CMD ["node", "dist/src/main"]
+CMD ["node", "dist/main"]


### PR DESCRIPTION
## Summary
This PR fixes a `MODULE_NOT_FOUND` error in the production server container.

### Changes
- Updated `docker/server/Dockerfile` to use `dist/main` instead of `dist/src/main`.
- This matches the actual output of `nest build` where the `src` directory is flattened in the `dist` folder.