### PR TITLE
fix(client): resolve lint errors in Patients page and e2e support

### DIFF
--- a/apps/client/src/pages/Patients.tsx
+++ b/apps/client/src/pages/Patients.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { PatientList } from '../components/patients/PatientList';
 import {
@@ -38,18 +38,13 @@ export default function Patients() {
   const updatePatient = useUpdatePatient();
   const deletePatient = useDeletePatient();
 
-  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [isCreateOpen, setIsCreateOpen] = useState(openCreateFromUrl);
   const [isEditOpen, setIsEditOpen] = useState(false);
   const [editPatient, setEditPatient] = useState<Patient | null>(null);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [patientToDelete, setPatientToDelete] = useState<Patient | null>(null);
   const openCreateFromUrl = searchParams.get('action') === 'new';
 
-  useEffect(() => {
-    if (openCreateFromUrl) {
-      setIsCreateOpen(true);
-    }
-  }, [openCreateFromUrl]);
 
   const closeCreateDialog = () => {
     setIsCreateOpen(false);

--- a/apps/client/tests/e2e/clinical/support/clinical-routes.ts
+++ b/apps/client/tests/e2e/clinical/support/clinical-routes.ts
@@ -1,4 +1,4 @@
-import { Page, expect } from '@playwright/test';
+import { Page } from '@playwright/test';
 
 export const mockPatientFlow = async (page: Page, overrides = {}) => {
   const patientId = 'p-canonical-1';


### PR DESCRIPTION
- Fix 'react-hooks/set-state-in-effect' in Patients.tsx by initializing state from search params.
- Remove unused 'expect' import in clinical-routes.ts.
- Remove unused 'useEffect' import in Patients.tsx.