### PR TITLE
fix(client): align Subjetivo voice flow with working evolution recorder

### DIFF
--- a/apps/client/src/api/media.ts
+++ b/apps/client/src/api/media.ts
@@ -6,6 +6,13 @@ import type {
   VoiceNote,
 } from '../types/patient';
 
+const getVoiceRecordingFilename = (mimeType: string): string => {
+  if (mimeType.includes('mp4')) return 'recording.m4a';
+  if (mimeType.includes('mpeg')) return 'recording.mp3';
+  if (mimeType.includes('wav')) return 'recording.wav';
+  return 'recording.webm';
+};
+
 export const mediaApi = {
   uploadPatientPhoto: async (patientId: string, file: Blob): Promise<void> => {
     const formData = new FormData();
@@ -74,7 +81,7 @@ export const mediaApi = {
     durationSeconds: number,
   ): Promise<VoiceNote> => {
     const formData = new FormData();
-    formData.append('file', file, 'recording.webm');
+    formData.append('file', file, getVoiceRecordingFilename(file.type));
     formData.append('durationSeconds', durationSeconds.toString());
 
     const response = await axios.post<VoiceNote>(
@@ -90,7 +97,7 @@ export const mediaApi = {
     durationSeconds: number,
   ): Promise<VoiceNote> => {
     const formData = new FormData();
-    formData.append('file', file, 'recording.webm');
+    formData.append('file', file, getVoiceRecordingFilename(file.type));
     formData.append('durationSeconds', durationSeconds.toString());
 
     const response = await axios.post<VoiceNote>(

--- a/apps/client/src/components/patients/EvaluationForm.test.tsx
+++ b/apps/client/src/components/patients/EvaluationForm.test.tsx
@@ -3,8 +3,42 @@ import { describe, expect, it, vi } from 'vitest';
 import { EvaluationForm } from './EvaluationForm';
 import type { ClinicalCase, Evaluation } from '../../types/patient';
 
+const { uploadEvaluationVoiceNoteMock } = vi.hoisted(() => ({
+  uploadEvaluationVoiceNoteMock: vi.fn(),
+}));
+
 vi.mock('./VoiceRecorder', () => ({
-  VoiceRecorder: () => <div data-testid="voice-recorder">Voice Recorder</div>,
+  VoiceRecorder: ({
+    onRecordingComplete,
+  }: {
+    onRecordingComplete: (blob: Blob, duration: number) => void;
+  }) => (
+    <button
+      data-testid="voice-recorder"
+      onClick={() =>
+        onRecordingComplete(new Blob(['audio'], { type: 'audio/webm' }), 3)
+      }
+    >
+      Voice Recorder
+    </button>
+  ),
+}));
+
+vi.mock('../../api/media', () => ({
+  mediaApi: {
+    uploadEvaluationVoiceNote: (...args: unknown[]) =>
+      uploadEvaluationVoiceNoteMock(...args),
+  },
+}));
+
+vi.mock('../../hooks/use-transcription-polling', () => ({
+  useTranscriptionPolling: () => ({
+    transcription: null,
+    status: 'completed',
+    error: null,
+    isPolling: false,
+    retry: vi.fn(),
+  }),
 }));
 
 vi.mock('../../hooks/use-toast', () => ({
@@ -86,6 +120,38 @@ const mockClinicalCase: ClinicalCase = {
 };
 
 describe('EvaluationForm SOAP', () => {
+  it('appends each new subjective transcript without overwriting previous text', async () => {
+    uploadEvaluationVoiceNoteMock
+      .mockResolvedValueOnce({
+        id: 'vn-1',
+        transcription: 'Primer dictado subjetivo',
+        transcriptionStatus: 'completed',
+      })
+      .mockResolvedValueOnce({
+        id: 'vn-2',
+        transcription: 'Segundo dictado subjetivo',
+        transcriptionStatus: 'completed',
+      });
+
+    render(<EvaluationForm clinicalCase={mockClinicalCase} onSave={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId('voice-recorder'));
+    await waitFor(() =>
+      expect(
+        screen.getByPlaceholderText('Motivo de consulta, historia y síntomas'),
+      ).toHaveValue('Primer dictado subjetivo'),
+    );
+
+    fireEvent.click(screen.getByText('New Recording'));
+    fireEvent.click(screen.getByTestId('voice-recorder'));
+
+    await waitFor(() =>
+      expect(
+        screen.getByPlaceholderText('Motivo de consulta, historia y síntomas'),
+      ).toHaveValue('Primer dictado subjetivo\nSegundo dictado subjetivo'),
+    );
+  });
+
   it('renders SOAP tabs', () => {
     render(<EvaluationForm clinicalCase={mockClinicalCase} />);
 

--- a/apps/client/src/components/patients/EvaluationForm.tsx
+++ b/apps/client/src/components/patients/EvaluationForm.tsx
@@ -9,7 +9,10 @@ import type {
 } from '../../types/patient';
 import { getActiveEvaluation } from '../../lib/evaluation-utils';
 import { VoiceRecorder } from './VoiceRecorder';
+import { TranscriptionDisplay } from './TranscriptionDisplay';
 import { useToast } from '../../hooks/use-toast';
+import { useTranscriptionPolling } from '../../hooks/use-transcription-polling';
+import { mediaApi } from '../../api/media';
 
 type SoapSection = 'subjective' | 'objective' | 'assessment' | 'plan';
 
@@ -67,6 +70,17 @@ export function EvaluationForm({
   >('idle');
 
   const [subjectiveText, setSubjectiveText] = React.useState('');
+  const [voiceNoteId, setVoiceNoteId] = React.useState<string | null>(null);
+  const [pendingVoiceNote, setPendingVoiceNote] = React.useState<{
+    blob: Blob;
+    duration: number;
+  } | null>(null);
+  const [pendingVoicePreviewUrl, setPendingVoicePreviewUrl] = React.useState<
+    string | null
+  >(null);
+  const [voiceUploadStatus, setVoiceUploadStatus] = React.useState<
+    'idle' | 'uploading' | 'success' | 'error'
+  >('idle');
   const [testSearch, setTestSearch] = React.useState('');
   const [selectedTests, setSelectedTests] = React.useState<string[]>(() =>
     getSelectedTestKeys(
@@ -100,8 +114,21 @@ export function EvaluationForm({
   const snapshotRef = React.useRef<string>('');
   const hasPendingChangesRef = React.useRef(false);
   const saveStatusTimerRef = React.useRef<number | null>(null);
+  const appendedTranscriptionIdsRef = React.useRef<Set<string>>(new Set());
   const onSaveRef = React.useRef(onSave);
   const buildPayloadRef = React.useRef<() => Evaluation | null>(() => null);
+
+  const {
+    transcription,
+    status: transcriptionStatus,
+    error: transcriptionError,
+    retry: retryTranscription,
+  } = useTranscriptionPolling({
+    entityType: 'evaluations',
+    entityId: activeEvaluation?.id || '',
+    voiceNoteId,
+    enabled: !!activeEvaluation?.id && !!voiceNoteId,
+  });
 
   React.useEffect(() => {
     onSaveRef.current = onSave;
@@ -145,6 +172,10 @@ export function EvaluationForm({
       },
     );
     setSubjectiveText(diagnosisWithSubjective.subjective || '');
+    setVoiceNoteId(null);
+    setPendingVoiceNote(null);
+    setVoiceUploadStatus('idle');
+    appendedTranscriptionIdsRef.current.clear();
 
     const hydratedSnapshot = JSON.stringify({
       orthopedicTests: (activeEvaluation.orthopedicTests ||
@@ -162,6 +193,65 @@ export function EvaluationForm({
     hasPendingChangesRef.current = false;
     hasHydratedRef.current = true;
   }, [activeEvaluation]);
+
+  React.useEffect(() => {
+    if (!pendingVoiceNote) {
+      setPendingVoicePreviewUrl((prev) => {
+        if (prev) {
+          URL.revokeObjectURL(prev);
+        }
+        return null;
+      });
+      return;
+    }
+
+    const nextUrl = URL.createObjectURL(pendingVoiceNote.blob);
+    setPendingVoicePreviewUrl((prev) => {
+      if (prev) {
+        URL.revokeObjectURL(prev);
+      }
+      return nextUrl;
+    });
+
+    return () => {
+      URL.revokeObjectURL(nextUrl);
+    };
+  }, [pendingVoiceNote]);
+
+  const appendSubjectiveTranscript = React.useCallback((text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+
+    hasPendingChangesRef.current = true;
+    setSubjectiveText((prev) =>
+      prev.trim() ? `${prev}\n${trimmed}` : trimmed,
+    );
+  }, []);
+
+  React.useEffect(() => {
+    if (
+      transcriptionStatus !== 'completed' ||
+      !transcription ||
+      !voiceNoteId ||
+      appendedTranscriptionIdsRef.current.has(voiceNoteId)
+    ) {
+      return;
+    }
+
+    appendSubjectiveTranscript(transcription);
+    appendedTranscriptionIdsRef.current.add(voiceNoteId);
+    setVoiceUploadStatus('success');
+    toast({
+      title: 'Dictado completado',
+      description: 'La transcripción se añadió al texto de Subjetivo.',
+    });
+  }, [
+    transcriptionStatus,
+    transcription,
+    voiceNoteId,
+    appendSubjectiveTranscript,
+    toast,
+  ]);
 
   const buildPayload = React.useCallback((): Evaluation | null => {
     if (!activeEvaluation) return null;
@@ -297,6 +387,59 @@ export function EvaluationForm({
     }
   };
 
+  const handleSubjectiveRecordingComplete = async (
+    blob: Blob,
+    duration: number,
+  ) => {
+    setPendingVoiceNote({ blob, duration });
+    setVoiceUploadStatus('uploading');
+
+    try {
+      const note = await mediaApi.uploadEvaluationVoiceNote(
+        activeEvaluation.id,
+        blob,
+        duration,
+      );
+
+      setVoiceNoteId(note.id);
+      setVoiceUploadStatus('success');
+
+      if (note.transcriptionStatus === 'failed') {
+        setVoiceUploadStatus('error');
+        toast({
+          title: 'Error de transcripción',
+          description:
+            note.transcriptionError || 'No se pudo transcribir el audio.',
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      if (note.transcription?.trim().length > 0) {
+        appendSubjectiveTranscript(note.transcription);
+        appendedTranscriptionIdsRef.current.add(note.id);
+        toast({
+          title: 'Dictado completado',
+          description: 'La transcripción se añadió al texto de Subjetivo.',
+        });
+      } else {
+        toast({
+          title: 'Procesando transcripción',
+          description:
+            'Tu audio se guardó. El texto aparecerá en unos segundos.',
+        });
+      }
+    } catch (error) {
+      setVoiceUploadStatus('error');
+      console.error('Subjective voice upload error:', error);
+      toast({
+        title: 'Error',
+        description: 'No se pudo guardar la grabación de voz en Subjetivo.',
+        variant: 'destructive',
+      });
+    }
+  };
+
   const hasDiagnosis = Boolean(
     diagnosis.functionalIndicator.trim() ||
     diagnosis.clinicalAspect.trim() ||
@@ -370,7 +513,41 @@ export function EvaluationForm({
           <p className="text-sm text-slate-500 dark:text-slate-400">
             Lo que el paciente reporta: sintomas, queja principal, historia.
           </p>
-          <VoiceRecorder onRecordingComplete={() => {}} className="w-full" />
+          {!pendingVoiceNote && !voiceNoteId && (
+            <VoiceRecorder
+              onRecordingComplete={handleSubjectiveRecordingComplete}
+              className="w-full"
+            />
+          )}
+          {(pendingVoiceNote || voiceNoteId) && (
+            <TranscriptionDisplay
+              status={
+                voiceUploadStatus === 'uploading'
+                  ? 'uploading'
+                  : voiceUploadStatus === 'error'
+                    ? 'failed'
+                    : transcriptionStatus === 'idle' ||
+                        transcriptionStatus === 'pending' ||
+                        transcriptionStatus === 'processing'
+                      ? 'pending'
+                      : transcriptionStatus
+              }
+              transcription={transcription || undefined}
+              audioUrl={pendingVoicePreviewUrl || undefined}
+              error={
+                transcriptionError ||
+                (voiceUploadStatus === 'error'
+                  ? 'No se pudo subir o transcribir el audio'
+                  : undefined)
+              }
+              onRetry={retryTranscription}
+              onRerecord={() => {
+                setVoiceNoteId(null);
+                setPendingVoiceNote(null);
+                setVoiceUploadStatus('idle');
+              }}
+            />
+          )}
           <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
             Motivo de consulta, historia y sintomas
           </label>

--- a/apps/client/src/hooks/use-voice-recorder.ts
+++ b/apps/client/src/hooks/use-voice-recorder.ts
@@ -23,6 +23,30 @@ export interface UseVoiceRecorderReturn {
   resetRecording: () => void;
 }
 
+const RECORDER_MIME_TYPE_CANDIDATES = [
+  'audio/webm;codecs=opus',
+  'audio/webm',
+  'audio/mp4;codecs=mp4a.40.2',
+  'audio/mp4',
+];
+
+function getSupportedRecorderMimeType(): string | null {
+  if (
+    typeof MediaRecorder === 'undefined' ||
+    typeof MediaRecorder.isTypeSupported !== 'function'
+  ) {
+    return null;
+  }
+
+  for (const mimeType of RECORDER_MIME_TYPE_CANDIDATES) {
+    if (MediaRecorder.isTypeSupported(mimeType)) {
+      return mimeType;
+    }
+  }
+
+  return null;
+}
+
 export function useVoiceRecorder({
   autoStart = false,
   autoSave = false,
@@ -71,7 +95,10 @@ export function useVoiceRecorder({
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       streamRef.current = stream;
 
-      const mediaRecorder = new MediaRecorder(stream);
+      const supportedMimeType = getSupportedRecorderMimeType();
+      const mediaRecorder = supportedMimeType
+        ? new MediaRecorder(stream, { mimeType: supportedMimeType })
+        : new MediaRecorder(stream);
       mediaRecorderRef.current = mediaRecorder;
       audioChunksRef.current = [];
 
@@ -86,7 +113,13 @@ export function useVoiceRecorder({
           clearInterval(timerRef.current);
           timerRef.current = null;
         }
-        const blob = new Blob(audioChunksRef.current, { type: 'audio/webm' });
+        const recorderMimeType =
+          mediaRecorder.mimeType ||
+          audioChunksRef.current[0]?.type ||
+          'audio/webm';
+        const blob = new Blob(audioChunksRef.current, {
+          type: recorderMimeType,
+        });
         setAudioBlob(blob);
         const url = URL.createObjectURL(blob);
         setAudioUrl(url);


### PR DESCRIPTION
## Summary
- Wire `Paciente Evaluation > Subjetivo` voice recording to the real upload/transcription pipeline so recordings are saved and transcribed.
- Replace old no-op subjective recorder behavior with the same status-driven recorder UX flow used by the working evolution voice path.
- Append new transcriptions into the Subjetivo textarea without overwriting previous notes.

## Validation
- `pnpm --filter client exec vitest run src/components/patients/EvaluationForm.test.tsx src/components/patients/EvaluationForm.spec.tsx`
- `TMPDIR=/tmp pnpm --filter client build`