### PR TITLE
fix(client): stabilize clinical case e2e readiness and pending-plan state

### DIFF
--- a/agent-os/specs/2026-02-28-patient-ai-analysis-refinement/verifications/2026-02-28-clinical-pending-banner.md
+++ b/agent-os/specs/2026-02-28-patient-ai-analysis-refinement/verifications/2026-02-28-clinical-pending-banner.md
@@ -1,0 +1,51 @@
+# Clinical Pending Banner Regression (2026-02-28)
+
+Objective: confirm the treatment plan pending banner renders for cases without defined phases and that the entire clinical journey flow remains green after the UI guard change.
+
+## Focused Tests
+
+1. `pnpm --filter client test TreatmentTimeline`
+   - Scope: new unit tests for `TreatmentTimeline` pending-banner logic (2 tests)
+   - Result: ✅ pass
+
+2. `pnpm --filter client exec playwright test apps/client/tests/e2e/clinical/clinical-happy-path.spec.ts`
+   - Scope: clinical happy path E2E to cover the pending banner and treatment plan unlock
+   - Result: ✅ pass (proxy warnings expected for AI analysis endpoints without backend)
+
+## Full Suite
+
+- `pnpm --filter client test:e2e`
+  - Scope: all Playwright E2E suites (30 tests)
+  - Result: ✅ pass (proxy warnings for AI endpoints remain expected; no test failures)
+
+Artifacts recorded locally at 2026-02-28 21:55 CET.
+
+## CI Failure Follow-Up (2026-03-01)
+
+Observed CI failures:
+
+- Missing pending banner assertion in `clinical-happy-path.spec.ts`
+- Missing timeline nav button in `stage-04-treatment-plan-phases-objectives.spec.ts`
+- Missing floating recorder button in `voice-recorder-resilience.spec.ts`
+
+Stabilization changes:
+
+- Added explicit mock for `GET /api/v1/ai/cases/:id/analyses/latest` in affected specs to avoid proxy-driven timing noise.
+- Added deterministic layout readiness checks (`nav-timeline-btn` visibility) before UI interactions.
+- Hardened list-route matching in voice resilience test to support query-string list requests while preserving detail route matching.
+
+Verification commands and outcomes:
+
+1. `pnpm --filter client exec playwright test apps/client/tests/e2e/clinical/clinical-happy-path.spec.ts apps/client/tests/e2e/clinical/stage-04-treatment-plan-phases-objectives.spec.ts apps/client/tests/e2e/clinical/voice/voice-recorder-resilience.spec.ts --workers=1`
+   - Result: ✅ pass
+
+2. `pnpm --filter client exec playwright test apps/client/tests/e2e/clinical/clinical-happy-path.spec.ts apps/client/tests/e2e/clinical/stage-04-treatment-plan-phases-objectives.spec.ts apps/client/tests/e2e/clinical/voice/voice-recorder-resilience.spec.ts --workers=1 --repeat-each=6`
+   - Result: ✅ pass (18/18)
+
+3. `pnpm --filter client test:e2e`
+   - Result: ✅ pass (30/30)
+
+4. `pnpm --filter client check-types`
+   - Result: ✅ pass
+
+Artifacts recorded locally at 2026-03-01 01:34 CET.

--- a/apps/client/src/components/patients/TreatmentTimeline.test.tsx
+++ b/apps/client/src/components/patients/TreatmentTimeline.test.tsx
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ClinicalCase, TreatmentPlan } from '../../types/patient';
+import { TreatmentTimeline } from './TreatmentTimeline';
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: vi.fn(),
+  }),
+}));
+
+vi.mock('../../api/patients', () => ({
+  patientsApi: {
+    addSession: vi.fn(),
+    updateSession: vi.fn(),
+    deleteSession: vi.fn(),
+  },
+}));
+
+vi.mock('../../api/media', () => ({
+  mediaApi: {
+    uploadSessionPhoto: vi.fn(),
+    uploadSessionVoiceNote: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/photo-queue', () => ({
+  photoQueue: {
+    getAll: vi.fn().mockResolvedValue([]),
+    remove: vi.fn(),
+  },
+  onOnline: () => () => void 0,
+  isOnline: () => true,
+}));
+
+vi.mock('./treatment-timeline/PhaseProgress', () => ({
+  PhaseProgress: () => <div data-testid="phase-progress" />,
+}));
+
+vi.mock('./treatment-timeline/SessionCard', () => ({
+  SessionCard: () => <div data-testid="session-card" />,
+}));
+
+vi.mock('./treatment-timeline/PainTrendChart', () => ({
+  PainTrendChart: () => <div data-testid="pain-chart" />,
+}));
+
+vi.mock('./treatment-timeline/SessionStatsSummary', () => ({
+  SessionStatsSummary: () => <div data-testid="session-stats" />,
+}));
+
+vi.mock('./treatment-timeline/SessionForm', () => ({
+  SessionForm: () => <div data-testid="session-form" />,
+}));
+
+function buildPlan(phases: TreatmentPlan['phases']): TreatmentPlan {
+  return {
+    id: 'plan-1',
+    clinicalCaseId: 'case-1',
+    createdAt: '2024-01-01T00:00:00Z',
+    objectives: {
+      therapeutic: '',
+      prophylactic: '',
+      educational: '',
+    },
+    phases,
+  };
+}
+
+function buildCase(overrides: Partial<ClinicalCase> = {}): ClinicalCase {
+  return {
+    id: 'case-1',
+    patientId: 'patient-1',
+    title: 'Test Case',
+    status: 'active',
+    startDate: '2024-01-01T00:00:00Z',
+    consultationReason: 'Test',
+    evaluation: undefined,
+    evaluations: [],
+    treatmentSessions: [],
+    treatmentPlan: buildPlan([]),
+    ...overrides,
+  };
+}
+
+describe('TreatmentTimeline', () => {
+  it('shows pending banner when treatment plan has no phases', () => {
+    const clinicalCase = buildCase({ treatmentPlan: buildPlan([]) });
+
+    render(
+      <TreatmentTimeline
+        clinicalCase={clinicalCase}
+        onSessionCreated={vi.fn()}
+        onSessionUpdated={vi.fn()}
+        onSessionDeleted={vi.fn()}
+        onSelectSession={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/Plan de tratamiento pendiente/i)).toBeVisible();
+  });
+
+  it('hides pending banner when treatment plan contains phases', () => {
+    const clinicalCase = buildCase({
+      treatmentPlan: buildPlan([
+        {
+          number: 1,
+          name: 'Fase 1',
+          durationWeeks: 2,
+          techniques: [],
+          objectives: 'Objetivo',
+        },
+      ]),
+    });
+
+    render(<TreatmentTimeline clinicalCase={clinicalCase} />);
+
+    expect(
+      screen.queryByText(/Plan de tratamiento pendiente/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/client/src/components/patients/TreatmentTimeline.tsx
+++ b/apps/client/src/components/patients/TreatmentTimeline.tsx
@@ -51,6 +51,11 @@ export function TreatmentTimeline({
   const { toast } = useToast();
 
   const { treatmentPlan, treatmentSessions } = clinicalCase;
+  const hasStructuredPlan = Boolean(
+    treatmentPlan &&
+    Array.isArray(treatmentPlan.phases) &&
+    treatmentPlan.phases.length > 0,
+  );
   const fallbackPhases = React.useMemo(
     () => [
       {
@@ -63,13 +68,12 @@ export function TreatmentTimeline({
     ],
     [],
   );
-  const timelinePhases =
-    treatmentPlan && treatmentPlan.phases.length > 0
-      ? treatmentPlan.phases
-      : fallbackPhases;
+  const timelinePhases = hasStructuredPlan
+    ? treatmentPlan!.phases
+    : fallbackPhases;
 
   React.useEffect(() => {
-    if (!treatmentPlan) {
+    if (!hasStructuredPlan) {
       return () => {};
     }
 
@@ -102,7 +106,7 @@ export function TreatmentTimeline({
     });
 
     return cleanup;
-  }, [toast, treatmentPlan]);
+  }, [toast, hasStructuredPlan]);
 
   const currentPhase =
     treatmentSessions.length > 0
@@ -278,7 +282,7 @@ export function TreatmentTimeline({
 
   return (
     <div className="max-w-5xl mx-auto space-y-6">
-      {!treatmentPlan && (
+      {!hasStructuredPlan && (
         <div className="bg-amber-50 dark:bg-amber-900/20 rounded-xl p-4 border border-amber-200 dark:border-amber-800">
           <h2 className="text-sm font-semibold text-amber-900 dark:text-amber-200 mb-1">
             Plan de tratamiento pendiente

--- a/apps/client/tests/e2e/clinical/clinical-happy-path.spec.ts
+++ b/apps/client/tests/e2e/clinical/clinical-happy-path.spec.ts
@@ -146,6 +146,17 @@ test.describe('Patient Clinical Journey - End to End', () => {
       });
     });
 
+    await page.route(
+      `**/api/v1/ai/cases/${caseId}/analyses/latest**`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(null),
+        });
+      },
+    );
+
     // 3. Mock Evaluation Patch
     await page.route(
       `**/api/v1/patients/evaluations/${evalId}`,
@@ -179,8 +190,19 @@ test.describe('Patient Clinical Journey - End to End', () => {
     await expect(
       page.locator('[role="dialog"][data-state="open"]'),
     ).toHaveCount(0, { timeout: 15000 });
-    await page.goto(`/pacientes/${patientId}/casos/${caseId}`, {
-      waitUntil: 'networkidle',
+    await Promise.all([
+      page.waitForResponse(
+        (response) =>
+          response.request().method() === 'GET' &&
+          response.url().includes(`/api/v1/patients/${patientId}`) &&
+          response.status() === 200,
+      ),
+      page.goto(`/pacientes/${patientId}/casos/${caseId}`, {
+        waitUntil: 'domcontentloaded',
+      }),
+    ]);
+    await expect(page.getByTestId('nav-timeline-btn')).toBeVisible({
+      timeout: 10000,
     });
     // Step 2: Verification of unblocking plan
     await expect(

--- a/apps/client/tests/e2e/clinical/stage-04-treatment-plan-phases-objectives.spec.ts
+++ b/apps/client/tests/e2e/clinical/stage-04-treatment-plan-phases-objectives.spec.ts
@@ -85,7 +85,23 @@ test.describe('Stage 4: Treatment Plan - Phases and Objectives', () => {
       });
     });
 
-    await page.goto(`/pacientes/${patientId}/casos/${caseId}`);
+    await page.route(
+      `**/api/v1/ai/cases/${caseId}/analyses/latest**`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(null),
+        });
+      },
+    );
+
+    await page.goto(`/pacientes/${patientId}/casos/${caseId}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await expect(page.getByTestId('nav-timeline-btn')).toBeVisible({
+      timeout: 10000,
+    });
 
     // Verify Timeline Tab
     await page.getByTestId('nav-timeline-btn').click();

--- a/apps/client/tests/e2e/clinical/voice/voice-recorder-resilience.spec.ts
+++ b/apps/client/tests/e2e/clinical/voice/voice-recorder-resilience.spec.ts
@@ -73,9 +73,35 @@ test.describe('Voice Recorder Resilience', () => {
 
     // Mock Patients List
     await page.route('**/api/v1/patients', async (route) => {
+      const url = new URL(route.request().url());
       if (
         route.request().method() === 'GET' &&
-        route.request().url().endsWith('/patients')
+        url.pathname.endsWith('/patients')
+      ) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: [
+              {
+                id: patientId,
+                name: 'Resilience Patient',
+                occupation: 'Tester',
+              },
+            ],
+            meta: { total: 1, page: 1, lastPage: 1 },
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.route('**/api/v1/patients?**', async (route) => {
+      const url = new URL(route.request().url());
+      if (
+        route.request().method() === 'GET' &&
+        url.pathname.endsWith('/patients')
       ) {
         await route.fulfill({
           status: 200,
@@ -150,6 +176,17 @@ test.describe('Voice Recorder Resilience', () => {
       });
     });
 
+    await page.route(
+      `**/api/v1/ai/cases/${caseId}/analyses/latest**`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(null),
+        });
+      },
+    );
+
     await page.route('**/api/v1/media/**', async (route) => {
       await route.fulfill({
         status: 201,
@@ -158,7 +195,20 @@ test.describe('Voice Recorder Resilience', () => {
       });
     });
 
-    await page.goto(`/pacientes/${patientId}/casos/${caseId}`);
+    await Promise.all([
+      page.waitForResponse(
+        (response) =>
+          response.request().method() === 'GET' &&
+          response.url().includes(`/api/v1/patients/${patientId}`) &&
+          response.status() === 200,
+      ),
+      page.goto(`/pacientes/${patientId}/casos/${caseId}`, {
+        waitUntil: 'domcontentloaded',
+      }),
+    ]);
+    await expect(page.getByTestId('nav-timeline-btn')).toBeVisible({
+      timeout: 10000,
+    });
 
     // Use header recorder (floating bar)
     await expect(page.getByTestId('floating-grabar-evolucion-btn')).toBeVisible(


### PR DESCRIPTION
## Summary
- Stabilize clinical E2E specs by waiting for case layout readiness before interacting with timeline and recorder controls
- Add missing AI latest-analysis route mocks and robust patient-list matching to remove CI proxy/timing flakiness
- Add pending-plan guard coverage in `TreatmentTimeline` and document CI follow-up verification under the active spec

## Verification
- pnpm --filter client exec playwright test apps/client/tests/e2e/clinical/clinical-happy-path.spec.ts apps/client/tests/e2e/clinical/stage-04-treatment-plan-phases-objectives.spec.ts apps/client/tests/e2e/clinical/voice/voice-recorder-resilience.spec.ts --workers=1
- pnpm --filter client exec playwright test apps/client/tests/e2e/clinical/clinical-happy-path.spec.ts apps/client/tests/e2e/clinical/stage-04-treatment-plan-phases-objectives.spec.ts apps/client/tests/e2e/clinical/voice/voice-recorder-resilience.spec.ts --workers=1 --repeat-each=6
- pnpm --filter client test:e2e
- pnpm --filter client check-types