### PR TITLE
chore(release): bump app to 1.0.1 and expose version in UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -110,7 +110,7 @@ LOG_OUTPUT=console
 
 # Service identification
 SERVICE_NAME=mamirri-server
-VERSION=0.0.1
+VERSION=1.0.1
 
 # Frontend Logging
 VITE_LOG_LEVEL=debug

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/client/src/components/MainLayout.tsx
+++ b/apps/client/src/components/MainLayout.tsx
@@ -50,6 +50,7 @@ export function MainLayout({ children }: MainLayoutProps) {
     clinicName: authUser?.clinicName ?? null,
     role: authUser?.role ?? null,
   };
+  const appVersion = import.meta.env.VITE_APP_VERSION || '1.0.1';
 
   const handleNavigate = (href: string) => {
     navigate(href);
@@ -67,6 +68,7 @@ export function MainLayout({ children }: MainLayoutProps) {
   return (
     <AppShell
       navigationItems={navigationItems}
+      appVersion={appVersion}
       user={user}
       onNavigate={handleNavigate}
       onLogout={handleLogout}

--- a/apps/client/src/components/auth/AuthLayout.tsx
+++ b/apps/client/src/components/auth/AuthLayout.tsx
@@ -2,12 +2,17 @@ import React from 'react';
 import { Outlet } from 'react-router-dom';
 
 const AuthLayout: React.FC = () => {
+  const appVersion = import.meta.env.VITE_APP_VERSION || '1.0.1';
+
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
           Mamirri App
         </h2>
+        <p className="mt-2 text-center text-sm font-medium text-gray-500">
+          v{appVersion}
+        </p>
       </div>
       <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
         <Outlet />

--- a/apps/client/src/components/shell/AppShell.tsx
+++ b/apps/client/src/components/shell/AppShell.tsx
@@ -5,6 +5,7 @@ import { UserMenu } from './UserMenu';
 export interface AppShellProps {
   children: React.ReactNode;
   navigationItems: Array<{ label: string; href: string; isActive?: boolean }>;
+  appVersion?: string;
   user?: {
     name: string;
     avatarUrl?: string;
@@ -19,6 +20,7 @@ export interface AppShellProps {
 export function AppShell({
   children,
   navigationItems,
+  appVersion,
   user,
   onNavigate,
   onLogout,
@@ -29,13 +31,18 @@ export function AppShell({
       <header className="bg-white dark:bg-slate-800">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
-            <div className="flex-shrink-0">
+            <div className="flex-shrink-0 flex items-center gap-2">
               <button
                 onClick={onLogoClick}
                 className="text-xl font-bold text-teal-600 dark:text-teal-400 hover:opacity-80 transition-opacity cursor-pointer focus:outline-none focus:bg-teal-50 dark:focus:bg-teal-900/50 rounded px-2 py-1"
               >
                 Mamirri
               </button>
+              {appVersion ? (
+                <span className="rounded-full border border-slate-200 dark:border-slate-700 px-2 py-0.5 text-xs font-medium text-slate-600 dark:text-slate-300">
+                  v{appVersion}
+                </span>
+              ) : null}
             </div>
 
             <nav className="flex-1 ml-8">

--- a/apps/client/src/lib/logger/logger.ts
+++ b/apps/client/src/lib/logger/logger.ts
@@ -238,6 +238,6 @@ export const logger = new Logger({
   format: 'json',
   output: import.meta.env.PROD ? 'stdout' : 'console',
   serviceName: 'mamirri-client',
-  version: '1.0.0',
+  version: import.meta.env.VITE_APP_VERSION || '1.0.1',
   environment: import.meta.env.MODE || 'development',
 });

--- a/apps/client/src/lib/sentry-init.ts
+++ b/apps/client/src/lib/sentry-init.ts
@@ -29,7 +29,7 @@ export async function initSentry(): Promise<void> {
       // Always capture 100% of sessions with errors
       replaysOnErrorSampleRate: 1.0,
       environment: import.meta.env.MODE,
-      release: import.meta.env.VITE_APP_VERSION || '1.0.0',
+      release: import.meta.env.VITE_APP_VERSION || '1.0.1',
       // PII Scrubbing for clinical data protection
       beforeSend(event) {
         // Remove sensitive headers

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "author": "",
   "private": true,

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -155,7 +155,7 @@ services:
       dockerfile: docker/client/Dockerfile
       args:
         VITE_SENTRY_DSN: ${VITE_SENTRY_DSN}
-        VITE_APP_VERSION: ${VERSION:-1.0.0}
+        VITE_APP_VERSION: ${VERSION:-1.0.1}
     container_name: physio_client
     environment:
       NODE_ENV: production

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mamirri-app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "build": "turbo run build",


### PR DESCRIPTION
## Summary
- bump app version metadata to `1.0.1` across root, client, and server packages
- expose `VITE_APP_VERSION` in the UI so users can verify the deployed app version on both authenticated and auth screens
- align release/version defaults for client logging, Sentry release, and production compose build args

## Why
- we improved SOAP evaluation and need users to clearly confirm they are on the updated build