### PR TITLE
fix(ai-analysis): handle empty latest analysis for new cases

### DIFF
--- a/apps/client/src/lib/logger/axios-logger.ts
+++ b/apps/client/src/lib/logger/axios-logger.ts
@@ -55,10 +55,25 @@ export function setupInterceptors(instance: AxiosInstance) {
         ? Date.now() - config.metadata.startTime
         : undefined;
 
+      const status = error.response?.status;
+      const url = config?.url ?? '';
+      const isExpectedLatestAnalysisMiss =
+        status === 404 &&
+        /\/ai\/cases\/[^/]+\/analyses\/latest(?:\?.*)?$/.test(url);
+
+      if (isExpectedLatestAnalysisMiss) {
+        logger.info('API Response: 404 latest analysis not found (expected)', {
+          status,
+          duration,
+          url,
+        });
+        return Promise.reject(error);
+      }
+
       logger.error(`API Error: ${error.message}`, error, {
-        status: error.response?.status,
+        status,
         duration,
-        url: config?.url,
+        url,
         code: error.code,
       });
 

--- a/apps/client/src/lib/logger/integration.spec.ts
+++ b/apps/client/src/lib/logger/integration.spec.ts
@@ -71,6 +71,39 @@ describe('Frontend Integration', () => {
     );
   });
 
+  it('should avoid error logs for expected latest-analysis 404', async () => {
+    const instance = axios.create();
+    setupInterceptors(instance);
+
+    instance.defaults.adapter = async (config) => {
+      throw {
+        response: {
+          status: 404,
+          data: { message: 'Analysis not found' },
+          headers: {},
+        },
+        message: 'Request failed with status code 404',
+        config: { ...config, url: '/ai/cases/case-123/analyses/latest' },
+        isAxiosError: true,
+      };
+    };
+
+    try {
+      await instance.get('/ai/cases/case-123/analyses/latest');
+    } catch {
+      // Expected
+    }
+
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('latest analysis not found (expected)'),
+      expect.objectContaining({
+        status: 404,
+        url: '/ai/cases/case-123/analyses/latest',
+      }),
+    );
+  });
+
   it('should send logs to backend aggregation endpoint', async () => {
     const testLogger = new Logger({
       level: LogLevel.DEBUG,

--- a/apps/server/src/modules/ai-analysis/ai-analysis.controller.spec.ts
+++ b/apps/server/src/modules/ai-analysis/ai-analysis.controller.spec.ts
@@ -214,14 +214,14 @@ describe('AiAnalysisController', () => {
       );
     });
 
-    it('should throw 404 for missing analysis', async () => {
-      service.getLatestAnalysis.mockRejectedValue(
-        new NotFoundException('Analysis not found'),
-      );
+    it('should return null when no analysis exists yet', async () => {
+      service.getLatestAnalysis.mockResolvedValue(null);
 
-      await expect(
-        controller.getLatestAnalysis('case-404', { userId: 'therapist-123' }),
-      ).rejects.toThrow(NotFoundException);
+      const result = await controller.getLatestAnalysis('case-404', {
+        userId: 'therapist-123',
+      });
+
+      expect(result).toBeNull();
     });
 
     it('should throw 403 for unauthorized access', async () => {

--- a/apps/server/src/modules/ai-analysis/ai-analysis.controller.ts
+++ b/apps/server/src/modules/ai-analysis/ai-analysis.controller.ts
@@ -297,7 +297,8 @@ export class AiAnalysisController {
   @ApiParam({ name: 'caseId', description: 'ID of the clinical case' })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Latest analysis retrieved successfully',
+    description:
+      'Latest analysis retrieved successfully (returns null when the case has no analyses yet)',
     type: AnalysisResultDto,
   })
   @ApiResponse({
@@ -311,7 +312,7 @@ export class AiAnalysisController {
   async getLatestAnalysis(
     @Param('caseId') caseId: string,
     @CurrentTherapist() user: { userId: string; clinicId?: string | null },
-  ): Promise<AnalysisResultDto> {
+  ): Promise<AnalysisResultDto | null> {
     return this.aiAnalysisService.getLatestAnalysis(
       caseId,
       user.userId,

--- a/apps/server/src/modules/ai-analysis/ai-analysis.persistence.spec.ts
+++ b/apps/server/src/modules/ai-analysis/ai-analysis.persistence.spec.ts
@@ -42,6 +42,9 @@ describe('AiAnalysis Persistence', () => {
         {
           provide: PrismaService,
           useValue: {
+            clinicalCase: {
+              findUnique: jest.fn(),
+            },
             aiAnalysis: {
               create: jest.fn().mockResolvedValue({ id: 'persisted-id' }),
               findFirst: jest.fn(),
@@ -140,6 +143,14 @@ describe('AiAnalysis Persistence', () => {
   });
 
   it('2.3 should return latest analysis when found', async () => {
+    ((prisma as any).clinicalCase.findUnique as jest.Mock).mockResolvedValue({
+      id: 'case-123',
+      patient: {
+        therapistId: 'therapist-123',
+        clinicId: 'clinic-123',
+      },
+    });
+
     ((prisma as any).aiAnalysis.findFirst as jest.Mock).mockResolvedValue({
       id: 'analysis-latest',
       result: {
@@ -149,29 +160,58 @@ describe('AiAnalysis Persistence', () => {
           rawModelResponse: '{"mock":true}',
         },
       },
-      clinicalCase: {
-        patient: {
-          therapistId: 'therapist-123',
-          clinicId: 'clinic-123',
-        },
-      },
     });
 
     const result = await service.getLatestAnalysis('case-123', 'therapist-123');
 
     expect((prisma as any).aiAnalysis.findFirst).toHaveBeenCalled();
+    expect(result).not.toBeNull();
+    if (!result) {
+      throw new Error('Expected latest analysis to be present');
+    }
     expect(result.metadata.analysisId).toBe('analysis-latest');
     expect(
       (result.metadata as { rawModelResponse?: string }).rawModelResponse,
     ).toBeUndefined();
   });
 
-  it('2.4 should throw not found when latest analysis does not exist', async () => {
+  it('2.4 should return null when latest analysis does not exist', async () => {
+    ((prisma as any).clinicalCase.findUnique as jest.Mock).mockResolvedValue({
+      id: 'case-404',
+      patient: {
+        therapistId: 'therapist-123',
+        clinicId: 'clinic-123',
+      },
+    });
     ((prisma as any).aiAnalysis.findFirst as jest.Mock).mockResolvedValue(null);
 
+    const result = await service.getLatestAnalysis('case-404', 'therapist-123');
+
+    expect(result).toBeNull();
+  });
+
+  it('2.5 should throw not found when clinical case does not exist', async () => {
+    ((prisma as any).clinicalCase.findUnique as jest.Mock).mockResolvedValue(
+      null,
+    );
+
     await expect(
-      service.getLatestAnalysis('case-404', 'therapist-123'),
-    ).rejects.toThrow('Analysis not found');
+      service.getLatestAnalysis('case-missing', 'therapist-123'),
+    ).rejects.toThrow('Clinical case not found');
+  });
+
+  it('2.6 should throw forbidden when therapist cannot access clinical case', async () => {
+    ((prisma as any).clinicalCase.findUnique as jest.Mock).mockResolvedValue({
+      id: 'case-123',
+      patient: {
+        therapistId: 'other-therapist',
+        clinicId: 'clinic-123',
+      },
+    });
+
+    await expect(
+      service.getLatestAnalysis('case-123', 'therapist-123'),
+    ).rejects.toThrow('You do not have access to this clinical case');
   });
 
   it('should return raw model response for owned analysis', async () => {

--- a/apps/server/src/modules/ai-analysis/ai-analysis.service.ts
+++ b/apps/server/src/modules/ai-analysis/ai-analysis.service.ts
@@ -43,6 +43,14 @@ type OwnedAnalysisRecord = {
   };
 };
 
+type OwnedClinicalCaseRecord = {
+  id: string;
+  patient: {
+    therapistId: string;
+    clinicId: string | null;
+  };
+};
+
 @Injectable()
 export class AiAnalysisService {
   private readonly logger = new Logger(AiAnalysisService.name);
@@ -212,29 +220,40 @@ export class AiAnalysisService {
     clinicalCaseId: string,
     therapistId: string,
     clinicId?: string | null,
-  ): Promise<AnalysisResult> {
+  ): Promise<AnalysisResult | null> {
+    const clinicalCase = (await (this.prisma as any).clinicalCase.findUnique({
+      where: { id: clinicalCaseId },
+      include: {
+        patient: true,
+      },
+    })) as OwnedClinicalCaseRecord | null;
+
+    if (!clinicalCase) {
+      throw new NotFoundException('Clinical case not found');
+    }
+
+    if (clinicalCase.patient.therapistId !== therapistId) {
+      throw new ForbiddenException(
+        'You do not have access to this clinical case',
+      );
+    }
+
+    if (clinicId && clinicalCase.patient.clinicId !== clinicId) {
+      throw new ForbiddenException(
+        'You do not have access to this clinical case',
+      );
+    }
+
     const latest = (await (this.prisma as any).aiAnalysis.findFirst({
       where: {
         clinicalCaseId,
       },
       orderBy: { createdAt: 'desc' },
-      include: {
-        clinicalCase: {
-          include: {
-            patient: true,
-          },
-        },
-      },
     })) as OwnedAnalysisRecord | null;
 
     if (!latest) {
-      throw new NotFoundException('Analysis not found');
+      return null;
     }
-
-    this.assertAnalysisAccess(latest, therapistId, clinicId, {
-      notFoundMessage: 'Analysis not found',
-      forbiddenMessage: 'You do not have access to this clinical case',
-    });
 
     const result = latest.result as StoredAnalysisResult;
 


### PR DESCRIPTION
## Summary
- return `null` from latest-analysis endpoint when a clinical case exists but has no analyses yet
- keep `404` for missing clinical case and `403` for unauthorized access
- downgrade expected latest-analysis 404 client logging noise and add regression tests

## Why
A newly created patient/case has no analyses yet, so opening the profile should render an empty state instead of surfacing noisy error behavior.

## Validation
- pnpm --filter server check-types
- pnpm --filter server test -- src/modules/ai-analysis/ai-analysis.controller.spec.ts src/modules/ai-analysis/ai-analysis.persistence.spec.ts
- pnpm --filter client check-types
- pnpm --filter client test -- src/lib/logger/integration.spec.ts
- pnpm --filter client build