### PR TITLE
feat(ai-analysis): store and display LLM prompts in Raw Analysis view

### DIFF
--- a/apps/client/src/api/ai-analysis.ts
+++ b/apps/client/src/api/ai-analysis.ts
@@ -13,6 +13,8 @@ export interface Feedback {
 export interface RawAnalysisResponse {
   analysisId: string;
   rawModelResponse: string | null;
+  systemPrompt: string | null;
+  userPrompt: string | null;
   createdAt: string;
   isRedacted: boolean;
 }

--- a/apps/client/src/components/patients/analysis/RawResponseDebugSection.tsx
+++ b/apps/client/src/components/patients/analysis/RawResponseDebugSection.tsx
@@ -14,6 +14,8 @@ export function RawResponseDebugSection({
   const [isLoading, setIsLoading] = useState(false);
   const [isSensitiveView, setIsSensitiveView] = useState(false);
   const [responseText, setResponseText] = useState<string | null>(null);
+  const [systemPrompt, setSystemPrompt] = useState<string | null>(null);
+  const [userPrompt, setUserPrompt] = useState<string | null>(null);
   const [isRedacted, setIsRedacted] = useState<boolean>(true);
 
   if (!isVisible || !analysisId) {
@@ -28,6 +30,8 @@ export function RawResponseDebugSection({
         includeSensitive,
       );
       setResponseText(response.rawModelResponse);
+      setSystemPrompt(response.systemPrompt);
+      setUserPrompt(response.userPrompt);
       setIsRedacted(response.isRedacted);
       setIsSensitiveView(includeSensitive);
     } finally {
@@ -72,9 +76,37 @@ export function RawResponseDebugSection({
           <p className="mt-3 text-xs text-slate-600 dark:text-slate-400">
             Modo actual: {isRedacted ? 'redactado' : 'sensible'}
           </p>
-          <pre className="mt-2 max-h-60 overflow-auto rounded-md bg-slate-900 p-3 text-xs text-slate-100">
-            {responseText || '(sin contenido raw)'}
-          </pre>
+
+          {systemPrompt && (
+            <div className="mt-3">
+              <h4 className="text-xs font-semibold text-amber-800 dark:text-amber-300">
+                System Prompt
+              </h4>
+              <pre className="mt-1 max-h-48 overflow-auto rounded-md bg-slate-900 p-3 text-xs text-slate-100">
+                {systemPrompt}
+              </pre>
+            </div>
+          )}
+
+          {userPrompt && (
+            <div className="mt-3">
+              <h4 className="text-xs font-semibold text-amber-800 dark:text-amber-300">
+                User Prompt
+              </h4>
+              <pre className="mt-1 max-h-48 overflow-auto rounded-md bg-slate-900 p-3 text-xs text-slate-100">
+                {userPrompt}
+              </pre>
+            </div>
+          )}
+
+          <div className="mt-3">
+            <h4 className="text-xs font-semibold text-amber-800 dark:text-amber-300">
+              Respuesta LLM
+            </h4>
+            <pre className="mt-1 max-h-60 overflow-auto rounded-md bg-slate-900 p-3 text-xs text-slate-100">
+              {responseText || '(sin contenido raw)'}
+            </pre>
+          </div>
         </>
       )}
     </div>

--- a/apps/server/src/modules/ai-analysis/ai-analysis.controller.spec.ts
+++ b/apps/server/src/modules/ai-analysis/ai-analysis.controller.spec.ts
@@ -240,6 +240,8 @@ describe('AiAnalysisController', () => {
       service.getRawModelResponse.mockResolvedValue({
         analysisId: 'analysis-123',
         rawModelResponse: '{"primarySuggestion":{"title":"Test"}}',
+        systemPrompt: 'You are a clinical assistant',
+        userPrompt: 'Analyze case data...',
         createdAt: new Date('2026-02-28T00:00:00.000Z'),
         isRedacted: true,
       });
@@ -255,6 +257,8 @@ describe('AiAnalysisController', () => {
 
       expect(result.analysisId).toBe('analysis-123');
       expect(result.rawModelResponse).toContain('primarySuggestion');
+      expect(result.systemPrompt).toBe('You are a clinical assistant');
+      expect(result.userPrompt).toBe('Analyze case data...');
       expect(result.isRedacted).toBe(true);
       expect(service.getRawModelResponse).toHaveBeenCalledWith(
         'analysis-123',
@@ -269,6 +273,8 @@ describe('AiAnalysisController', () => {
       service.getRawModelResponse.mockResolvedValue({
         analysisId: 'analysis-123',
         rawModelResponse: '{"private":true}',
+        systemPrompt: 'system prompt',
+        userPrompt: 'user prompt',
         createdAt: new Date('2026-02-28T00:00:00.000Z'),
         isRedacted: false,
       });

--- a/apps/server/src/modules/ai-analysis/ai-analysis.persistence.spec.ts
+++ b/apps/server/src/modules/ai-analysis/ai-analysis.persistence.spec.ts
@@ -75,8 +75,8 @@ describe('AiAnalysis Persistence', () => {
         {
           provide: PromptBuilderService,
           useValue: {
-            buildSystemPrompt: jest.fn(),
-            buildUserPrompt: jest.fn(),
+            buildSystemPrompt: jest.fn().mockReturnValue('mock-system-prompt'),
+            buildUserPrompt: jest.fn().mockReturnValue('mock-user-prompt'),
             buildDiagnosisQuery: jest.fn(),
             buildTreatmentQuery: jest.fn(),
             buildContraindicationsQuery: jest.fn(),
@@ -119,6 +119,8 @@ describe('AiAnalysis Persistence', () => {
         result: expect.objectContaining({
           metadata: expect.objectContaining({
             rawModelResponse: expect.any(String),
+            systemPrompt: 'mock-system-prompt',
+            userPrompt: 'mock-user-prompt',
           }),
         }),
       }),
@@ -158,6 +160,8 @@ describe('AiAnalysis Persistence', () => {
         metadata: {
           ...mockAnalysisResult.metadata,
           rawModelResponse: '{"mock":true}',
+          systemPrompt: 'stored-system-prompt',
+          userPrompt: 'stored-user-prompt',
         },
       },
     });
@@ -172,6 +176,12 @@ describe('AiAnalysis Persistence', () => {
     expect(result.metadata.analysisId).toBe('analysis-latest');
     expect(
       (result.metadata as { rawModelResponse?: string }).rawModelResponse,
+    ).toBeUndefined();
+    expect(
+      (result.metadata as { systemPrompt?: string }).systemPrompt,
+    ).toBeUndefined();
+    expect(
+      (result.metadata as { userPrompt?: string }).userPrompt,
     ).toBeUndefined();
   });
 
@@ -223,6 +233,8 @@ describe('AiAnalysis Persistence', () => {
         metadata: {
           ...mockAnalysisResult.metadata,
           rawModelResponse: '{"debug":true}',
+          systemPrompt: 'You are a clinical assistant',
+          userPrompt: 'Analyze this case: test@example.com',
         },
       },
       clinicalCase: {
@@ -242,6 +254,8 @@ describe('AiAnalysis Persistence', () => {
 
     expect(response.analysisId).toBe('analysis-raw-1');
     expect(response.rawModelResponse).toBe('{"debug":true}');
+    expect(response.systemPrompt).toBe('You are a clinical assistant');
+    expect(response.userPrompt).toContain('[REDACTED_EMAIL]');
     expect(response.isRedacted).toBe(true);
   });
 
@@ -271,6 +285,8 @@ describe('AiAnalysis Persistence', () => {
     );
 
     expect(response.rawModelResponse).toBeNull();
+    expect(response.systemPrompt).toBeNull();
+    expect(response.userPrompt).toBeNull();
     expect(response.isRedacted).toBe(true);
   });
 
@@ -307,6 +323,8 @@ describe('AiAnalysis Persistence', () => {
         metadata: {
           ...mockAnalysisResult.metadata,
           rawModelResponse: '{"adminView":true}',
+          systemPrompt: 'admin-system-prompt',
+          userPrompt: 'admin-user-prompt',
         },
       },
       clinicalCase: {
@@ -326,6 +344,8 @@ describe('AiAnalysis Persistence', () => {
     );
 
     expect(response.rawModelResponse).toBe('{"adminView":true}');
+    expect(response.systemPrompt).toBe('admin-system-prompt');
+    expect(response.userPrompt).toBe('admin-user-prompt');
     expect(response.isRedacted).toBe(false);
   });
 
@@ -339,6 +359,10 @@ describe('AiAnalysis Persistence', () => {
           ...mockAnalysisResult.metadata,
           rawModelResponse:
             'Contact test@example.com phone +356 9912 3456 token eyJabc.def.ghi',
+          systemPrompt:
+            'System prompt with email admin@clinic.com',
+          userPrompt:
+            'User prompt with phone +356 7777 8888',
         },
       },
       clinicalCase: {
@@ -360,6 +384,8 @@ describe('AiAnalysis Persistence', () => {
     expect(response.rawModelResponse).toContain('[REDACTED_EMAIL]');
     expect(response.rawModelResponse).toContain('[REDACTED_PHONE]');
     expect(response.rawModelResponse).toContain('[REDACTED_TOKEN]');
+    expect(response.systemPrompt).toContain('[REDACTED_EMAIL]');
+    expect(response.userPrompt).toContain('[REDACTED_PHONE]');
   });
 
   it('should reject therapist role for raw response endpoint', async () => {

--- a/apps/server/src/modules/ai-analysis/ai-analysis.service.ts
+++ b/apps/server/src/modules/ai-analysis/ai-analysis.service.ts
@@ -28,7 +28,11 @@ import { CaseDataAggregate } from './interfaces/aggregation.interfaces';
 import { ROLES, type Role } from '../../common/constants/roles';
 
 type StoredAnalysisResult = AnalysisResult & {
-  metadata?: AnalysisResult['metadata'] & { rawModelResponse?: string };
+  metadata?: AnalysisResult['metadata'] & {
+    rawModelResponse?: string;
+    systemPrompt?: string;
+    userPrompt?: string;
+  };
 };
 
 type OwnedAnalysisRecord = {
@@ -191,6 +195,8 @@ export class AiAnalysisService {
         metadata: {
           ...resultWithoutId.metadata,
           rawModelResponse: llmResponse,
+          systemPrompt,
+          userPrompt,
         },
       };
 
@@ -261,8 +267,12 @@ export class AiAnalysisService {
       ...(result.metadata || {}),
     } as AnalysisResult['metadata'] & {
       rawModelResponse?: string;
+      systemPrompt?: string;
+      userPrompt?: string;
     };
     delete sanitizedMetadata.rawModelResponse;
+    delete sanitizedMetadata.systemPrompt;
+    delete sanitizedMetadata.userPrompt;
 
     return {
       ...result,
@@ -282,6 +292,8 @@ export class AiAnalysisService {
   ): Promise<{
     analysisId: string;
     rawModelResponse: string | null;
+    systemPrompt: string | null;
+    userPrompt: string | null;
     createdAt: Date;
     isRedacted: boolean;
   }> {
@@ -310,10 +322,27 @@ export class AiAnalysisService {
       typeof result.metadata?.rawModelResponse === 'string'
         ? result.metadata.rawModelResponse
         : null;
+    const storedSystemPrompt =
+      typeof result.metadata?.systemPrompt === 'string'
+        ? result.metadata.systemPrompt
+        : null;
+    const storedUserPrompt =
+      typeof result.metadata?.userPrompt === 'string'
+        ? result.metadata.userPrompt
+        : null;
+
     const responseText =
       rawModelResponse && !includeSensitive
         ? this.redactRawModelResponse(rawModelResponse)
         : rawModelResponse;
+    const systemPromptText =
+      storedSystemPrompt && !includeSensitive
+        ? this.redactRawModelResponse(storedSystemPrompt)
+        : storedSystemPrompt;
+    const userPromptText =
+      storedUserPrompt && !includeSensitive
+        ? this.redactRawModelResponse(storedUserPrompt)
+        : storedUserPrompt;
 
     this.logRawResponseAccess({
       analysisId,
@@ -327,6 +356,8 @@ export class AiAnalysisService {
     return {
       analysisId: analysis.id,
       rawModelResponse: responseText,
+      systemPrompt: systemPromptText,
+      userPrompt: userPromptText,
       createdAt: analysis.createdAt,
       isRedacted: !includeSensitive,
     };

--- a/apps/server/src/modules/ai-analysis/dto/raw-analysis-response.dto.ts
+++ b/apps/server/src/modules/ai-analysis/dto/raw-analysis-response.dto.ts
@@ -10,6 +10,18 @@ export class RawAnalysisResponseDto {
   })
   rawModelResponse: string | null;
 
+  @ApiProperty({
+    description: 'System prompt sent to the LLM model',
+    nullable: true,
+  })
+  systemPrompt: string | null;
+
+  @ApiProperty({
+    description: 'User prompt sent to the LLM model',
+    nullable: true,
+  })
+  userPrompt: string | null;
+
   @ApiProperty({ description: 'Timestamp when analysis was created' })
   createdAt: Date;
 


### PR DESCRIPTION
## Summary
- Persist `systemPrompt` and `userPrompt` alongside `rawModelResponse` in the `AiAnalysis` result JSON for debugging and prompt tuning
- Return prompts from `getRawModelResponse` API endpoint with redaction support (emails, phones, tokens stripped by default)
- Display System Prompt, User Prompt, and LLM Response as separate labeled sections in the frontend `RawResponseDebugSection` panel

## Changes

### Backend (`apps/server`)
- **`ai-analysis.service.ts`**: Extended `StoredAnalysisResult` type, persisted prompts in `analyzeCase`, stripped them from `getLatestAnalysis`, and returned them (with redaction) from `getRawModelResponse`
- **`dto/raw-analysis-response.dto.ts`**: Added `systemPrompt` and `userPrompt` nullable fields to Swagger DTO
- **`ai-analysis.persistence.spec.ts`**: Updated tests to verify prompt persistence, stripping from latest analysis, redaction, and admin access
- **`ai-analysis.controller.spec.ts`**: Updated mock responses to include prompt fields

### Frontend (`apps/client`)
- **`api/ai-analysis.ts`**: Added `systemPrompt` and `userPrompt` to `RawAnalysisResponse` interface
- **`RawResponseDebugSection.tsx`**: Added state for prompts, displays them in separate collapsible sections with labeled headers

## Notes
- No Prisma schema migration needed — prompts are stored inside the existing `result` JSON column
- Prompts are **never** exposed via `getLatestAnalysis` (same treatment as `rawModelResponse`)
- Redaction applies to prompts when `includeSensitive=false` (default)

Closes #87